### PR TITLE
Add testing infrastructure and dual publishing setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: Run tests
+        run: npm run test:run
+
       - name: Build
         run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to NPM
+name: Publish Package
 
 on:
   push:
@@ -11,6 +11,7 @@ jobs:
 
     permissions:
       contents: read
+      packages: write
       id-token: write
 
     steps:
@@ -21,16 +22,52 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Run tests
+        run: npm run test:run
+
       - name: Build
         run: npm run build
 
+      # Publish to NPM (if NPM_TOKEN is configured)
+      - name: Check NPM Token
+        id: check-npm-token
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "npm_token_exists=false" >> $GITHUB_OUTPUT
+            echo "⚠️  NPM_TOKEN is not configured. Skipping NPM publish."
+            echo "To publish to NPM, add NPM_TOKEN to repository secrets."
+          else
+            echo "npm_token_exists=true" >> $GITHUB_OUTPUT
+            echo "✅ NPM_TOKEN is configured. Will publish to NPM."
+          fi
+
+      - name: Setup Node.js for NPM
+        if: steps.check-npm-token.outputs.npm_token_exists == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Publish to NPM
+        if: steps.check-npm-token.outputs.npm_token_exists == 'true'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Always publish to GitHub Packages
+      - name: Setup Node.js for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@choigawoon'
+
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Thumbs.db
 # Logs
 *.log
 npm-debug.log*
+
+# Test coverage
+coverage/

--- a/docs/NPM-PUBLISH-SETUP.md
+++ b/docs/NPM-PUBLISH-SETUP.md
@@ -1,0 +1,146 @@
+# NPM Publishing Setup Guide
+
+This document explains how to configure NPM publishing for this package.
+
+## Overview
+
+The package is configured to publish to two registries:
+
+1. **GitHub Packages** (Always enabled - no setup required)
+2. **NPM Public Registry** (Optional - requires NPM_TOKEN)
+
+## GitHub Packages
+
+GitHub Packages publishing is **automatically enabled** and requires no additional setup. It uses the `GITHUB_TOKEN` that GitHub Actions provides automatically.
+
+- **Registry**: `https://npm.pkg.github.com`
+- **Package URL**: `https://github.com/choigawoon/boilerplate/packages`
+- **Authentication**: Automatic via `GITHUB_TOKEN`
+
+### Installing from GitHub Packages
+
+Users need to configure their `.npmrc`:
+
+```bash
+@choigawoon:registry=https://npm.pkg.github.com
+```
+
+Then install with:
+
+```bash
+npm install @choigawoon/boilerplate
+```
+
+## NPM Public Registry (Optional)
+
+To publish to the public NPM registry, you need to configure an NPM access token.
+
+### Step 1: Generate NPM Access Token
+
+1. Log in to [npmjs.com](https://www.npmjs.com)
+2. Go to **Account Settings** → **Access Tokens**
+3. Click **Generate New Token** → **Granular Access Token**
+4. Configure the token:
+   - **Token Name**: `github-actions-boilerplate`
+   - **Expiration**: Choose appropriate expiration (e.g., 90 days, 1 year, or no expiration)
+   - **Packages and scopes**: Select your package scope (`@choigawoon`)
+   - **Permissions**:
+     - Read and write access to packages
+5. Click **Generate Token**
+6. **Copy the token immediately** (you won't be able to see it again)
+
+### Step 2: Add Token to GitHub Secrets
+
+1. Go to your repository on GitHub
+2. Navigate to **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Add the secret:
+   - **Name**: `NPM_TOKEN`
+   - **Value**: Paste the NPM access token you copied
+5. Click **Add secret**
+
+### Step 3: Verify Configuration
+
+Once `NPM_TOKEN` is added, the workflow will:
+- ✅ Detect the token exists
+- ✅ Publish to NPM with provenance
+- ✅ Display: "NPM_TOKEN is configured. Will publish to NPM."
+
+If `NPM_TOKEN` is not configured:
+- ⚠️ Skip NPM publishing
+- ⚠️ Display: "NPM_TOKEN is not configured. Skipping NPM publish."
+- ✅ Still publish to GitHub Packages
+
+## Publishing a New Version
+
+### Manual Release
+
+1. Update version in `package.json`:
+   ```bash
+   npm version patch  # or minor, major
+   ```
+
+2. Push the tag:
+   ```bash
+   git push origin v0.0.2
+   ```
+
+3. GitHub Actions will automatically:
+   - Run tests
+   - Build the package
+   - Publish to GitHub Packages (always)
+   - Publish to NPM (if NPM_TOKEN exists)
+
+### Automated Release (Future Enhancement)
+
+Consider using tools like:
+- **semantic-release**: Automated versioning and changelog
+- **release-please**: Google's release automation tool
+
+## Checking Publish Status
+
+After pushing a tag, check the workflow status:
+
+1. Go to **Actions** tab in your repository
+2. Find the "Publish Package" workflow
+3. Check the logs:
+   - ✅ "NPM_TOKEN is configured" = Publishing to NPM
+   - ⚠️ "NPM_TOKEN is not configured" = Skipping NPM (GitHub Packages only)
+
+## Troubleshooting
+
+### NPM Publish Fails
+
+**Error: `E401 Unauthorized`**
+- Token expired or invalid
+- Regenerate NPM token and update GitHub secret
+
+**Error: `E403 Forbidden`**
+- Token doesn't have write permissions
+- Check token scope includes your package
+
+**Error: `E404 Package not found`**
+- First time publishing: Go to npmjs.com and create the package manually
+- Or use `npm publish` locally first
+
+### GitHub Packages Publish Fails
+
+**Error: `E401 Unauthorized`**
+- Check workflow has `packages: write` permission (already configured)
+
+**Error: `E404 or E403`**
+- Check repository settings → Actions → General
+- Ensure "Read and write permissions" is enabled
+
+## Security Best Practices
+
+1. **Use Granular Access Tokens**: Modern NPM tokens with limited scope
+2. **Set Token Expiration**: Rotate tokens periodically
+3. **Provenance Enabled**: Package includes build provenance metadata
+4. **Don't Commit Tokens**: Never commit `.npmrc` with tokens to git
+
+## Resources
+
+- [NPM Access Tokens Documentation](https://docs.npmjs.com/creating-and-viewing-access-tokens)
+- [GitHub Packages NPM Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry)
+- [NPM Provenance](https://docs.npmjs.com/generating-provenance-statements)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
+        "@vitest/ui": "^4.0.14",
         "tsup": "^8.0.0",
-        "typescript": "^5.3.0"
+        "typescript": "^5.3.0",
+        "vitest": "^4.0.14"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -494,6 +496,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.53.3",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
@@ -802,12 +811,170 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.14.tgz",
+      "integrity": "sha512-RHk63V3zvRiYOWAV0rGEBRO820ce17hz7cI2kDmEdfQsBjT2luEKB5tCOc91u1oSQoUOZkSv3ZyzkdkSLD7lKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.14",
+        "@vitest/utils": "4.0.14",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.14.tgz",
+      "integrity": "sha512-RzS5NujlCzeRPF1MK7MXLiEFpkIXeMdQ+rN3Kk3tDI9j0mtbr7Nmuq67tpkOJQpgyClbOltCXMjLZicJHsH5Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.14",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.14.tgz",
+      "integrity": "sha512-SOYPgujB6TITcJxgd3wmsLl+wZv+fy3av2PpiPpsWPZ6J1ySUYfScfpIt2Yv56ShJXR2MOA6q2KjKHN4EpdyRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.14.tgz",
+      "integrity": "sha512-BsAIk3FAqxICqREbX8SetIteT8PiaUL/tgJjmhxJhCsigmzzH8xeadtp7LRnTpCVzvf0ib9BgAfKJHuhNllKLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.14",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.14.tgz",
+      "integrity": "sha512-aQVBfT1PMzDSA16Y3Fp45a0q8nKexx6N5Amw3MX55BeTeZpoC08fGqEZqVmPcqN0ueZsuUQ9rriPMhZ3Mu19Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.14",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.14.tgz",
+      "integrity": "sha512-JmAZT1UtZooO0tpY3GRyiC/8W7dCs05UOq9rfsUUgEZEdq+DuHLmWhPsrTt0TiW7WYeL/hXpaE07AZ2RCk44hg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.14.tgz",
+      "integrity": "sha512-fvDz8o7SQpFLoSBo6Cudv+fE85/fPCkwTnLAN85M+Jv7k59w2mSIjT9Q5px7XwGrmYqqKBEYxh/09IBGd1E7AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.14",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.14"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.14.tgz",
+      "integrity": "sha512-hLqXZKAWNg8pI+SQXyXxWCTOpA3MvsqcbVeNgSi8x/CSN2wi26dSzn1wrOhmCmFjEvN9p8/kLFRHa6PI8jHazw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.14",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -828,6 +995,16 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -853,6 +1030,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
+      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -916,6 +1103,13 @@
         }
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
@@ -958,6 +1152,26 @@
         "@esbuild/win32-x64": "0.27.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -976,6 +1190,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -987,6 +1208,13 @@
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
       }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1066,6 +1294,16 @@
         "ufo": "^1.6.1"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1085,6 +1323,25 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1094,6 +1351,17 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1142,6 +1410,35 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-load-config": {
@@ -1253,6 +1550,28 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -1262,6 +1581,30 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -1309,6 +1652,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -1331,6 +1681,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tree-kill": {
@@ -1423,6 +1793,660 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
+      "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.14.tgz",
+      "integrity": "sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.14",
+        "@vitest/mocker": "4.0.14",
+        "@vitest/pretty-format": "4.0.14",
+        "@vitest/runner": "4.0.14",
+        "@vitest/snapshot": "4.0.14",
+        "@vitest/spy": "4.0.14",
+        "@vitest/utils": "4.0.14",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.14",
+        "@vitest/browser-preview": "4.0.14",
+        "@vitest/browser-webdriverio": "4.0.14",
+        "@vitest/ui": "4.0.14",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit"
   },
@@ -30,10 +34,17 @@
   "author": "choigawoon",
   "license": "MIT",
   "devDependencies": {
+    "@vitest/ui": "^4.0.14",
     "tsup": "^8.0.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "vitest": "^4.0.14"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/choigawoon/boilerplate.git"
   }
 }

--- a/setup-project-board.sh
+++ b/setup-project-board.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+set -e  # Exit on error
+
+# GitHub Project Board Setup Script
+# This script creates a GitHub Project and adds issues to it
+
+OWNER="choigawoon"
+REPO="boilerplate"
+PROJECT_TITLE="NPM Package Boilerplate Development"
+
+echo "=================================================="
+echo "GitHub Project Board Setup"
+echo "=================================================="
+echo ""
+
+# Step 1: Create GitHub Project
+echo "[1/3] Creating GitHub Project: $PROJECT_TITLE"
+PROJECT_JSON=$(gh project create \
+  --owner "$OWNER" \
+  --title "$PROJECT_TITLE" \
+  --format json)
+
+PROJECT_URL=$(echo "$PROJECT_JSON" | jq -r '.url')
+PROJECT_NUMBER=$(echo "$PROJECT_JSON" | jq -r '.number')
+
+echo "✓ Project created successfully"
+echo "  URL: $PROJECT_URL"
+echo "  Number: $PROJECT_NUMBER"
+echo ""
+
+# Step 2: Create issues with labels
+echo "[2/3] Creating issues..."
+echo ""
+
+# Issue 1: NPM Publishing
+echo "Creating issue 1/6: NPM 퍼블리시 설정 및 테스트"
+ISSUE_1=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "NPM 퍼블리시 설정 및 테스트" \
+  --body "## 목표
+NPM 레지스트리에 패키지를 자동으로 퍼블리시하는 워크플로우를 설정하고 테스트합니다.
+
+## 작업 내용
+- [ ] NPM_TOKEN secrets 설정 가이드 작성
+- [ ] .github/workflows/publish.yml 워크플로우 검증
+- [ ] 테스트 퍼블리시 실행
+- [ ] 버전 태그 자동화 확인
+
+## 참고사항
+- NPM 계정 및 organization 권한 필요
+- package.json의 name, version 필드 확인
+- 퍼블리시 전 빌드 과정 검증" \
+  --label "enhancement,ci/cd" \
+  --format json)
+
+ISSUE_1_NUMBER=$(echo "$ISSUE_1" | jq -r '.number')
+ISSUE_1_ID=$(echo "$ISSUE_1" | jq -r '.id')
+echo "  ✓ Issue #$ISSUE_1_NUMBER created"
+
+# Issue 2: CI/CD Testing
+echo "Creating issue 2/6: CI/CD 워크플로우 테스트"
+ISSUE_2=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "CI/CD 워크플로우 테스트" \
+  --body "## 목표
+GitHub Actions 워크플로우가 모든 시나리오에서 정상 동작하는지 테스트합니다.
+
+## 작업 내용
+- [ ] PR 생성 시 빌드 및 린트 테스트
+- [ ] PR 머지 시 자동 배포 테스트
+- [ ] 실패 케이스 핸들링 확인
+- [ ] 워크플로우 실행 시간 최적화
+
+## 테스트 시나리오
+1. 새 브랜치에서 PR 생성
+2. 코드 리뷰 및 수정
+3. main 브랜치로 머지
+4. 자동 배포 확인" \
+  --label "testing,ci/cd" \
+  --format json)
+
+ISSUE_2_NUMBER=$(echo "$ISSUE_2" | jq -r '.number')
+ISSUE_2_ID=$(echo "$ISSUE_2" | jq -r '.id')
+echo "  ✓ Issue #$ISSUE_2_NUMBER created"
+
+# Issue 3: Version Management
+echo "Creating issue 3/6: 패키지 버전 관리 자동화"
+ISSUE_3=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "패키지 버전 관리 자동화" \
+  --body "## 목표
+Semantic versioning과 changelog 자동 생성을 통해 버전 관리를 자동화합니다.
+
+## 작업 내용
+- [ ] semantic-release 또는 changesets 도입 검토
+- [ ] 커밋 메시지 컨벤션 정의 (conventional commits)
+- [ ] CHANGELOG.md 자동 생성 설정
+- [ ] Git 태그 자동 생성 워크플로우
+- [ ] 버전 범프 자동화 (patch/minor/major)
+
+## 고려사항
+- Breaking changes 감지 및 major 버전 업데이트
+- Release notes 자동 생성
+- NPM 퍼블리시 연동" \
+  --label "enhancement,automation" \
+  --format json)
+
+ISSUE_3_NUMBER=$(echo "$ISSUE_3" | jq -r '.number')
+ISSUE_3_ID=$(echo "$ISSUE_3" | jq -r '.id')
+echo "  ✓ Issue #$ISSUE_3_NUMBER created"
+
+# Issue 4: Example Project
+echo "Creating issue 4/6: 예제 프로젝트 추가"
+ISSUE_4=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "예제 프로젝트 추가" \
+  --body "## 목표
+이 boilerplate를 사용하는 방법을 보여주는 예제 프로젝트를 추가합니다.
+
+## 작업 내용
+- [ ] examples/ 디렉토리 생성
+- [ ] 기본 사용법 예제 작성
+- [ ] TypeScript 설정 예제
+- [ ] 빌드 및 퍼블리시 예제
+- [ ] README.md에 예제 링크 추가
+
+## 예제 시나리오
+1. 새 NPM 패키지 시작하기
+2. 기존 프로젝트를 boilerplate로 마이그레이션
+3. CI/CD 워크플로우 커스터마이징" \
+  --label "documentation,enhancement" \
+  --format json)
+
+ISSUE_4_NUMBER=$(echo "$ISSUE_4" | jq -r '.number')
+ISSUE_4_ID=$(echo "$ISSUE_4" | jq -r '.id')
+echo "  ✓ Issue #$ISSUE_4_NUMBER created"
+
+# Issue 5: Unit Tests
+echo "Creating issue 5/6: 단위 테스트 추가"
+ISSUE_5=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "단위 테스트 추가" \
+  --body "## 목표
+Jest 또는 Vitest를 사용하여 단위 테스트 환경을 구축합니다.
+
+## 작업 내용
+- [ ] 테스트 프레임워크 선택 (Jest vs Vitest)
+- [ ] 테스트 환경 설정
+- [ ] 샘플 테스트 작성
+- [ ] CI/CD에 테스트 단계 추가
+- [ ] 코드 커버리지 리포팅 설정
+
+## 테스트 범위
+- 빌드 스크립트 테스트
+- 설정 파일 검증 테스트
+- 유틸리티 함수 테스트 (있는 경우)
+
+## 성공 기준
+- 모든 PR에서 테스트 자동 실행
+- 테스트 커버리지 80% 이상" \
+  --label "testing,enhancement" \
+  --format json)
+
+ISSUE_5_NUMBER=$(echo "$ISSUE_5" | jq -r '.number')
+ISSUE_5_ID=$(echo "$ISSUE_5" | jq -r '.id')
+echo "  ✓ Issue #$ISSUE_5_NUMBER created"
+
+# Issue 6: AI Agent PR Guide
+echo "Creating issue 6/6: AI Agent PR 자동화 가이드 작성"
+ISSUE_6=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "AI Agent PR 자동화 가이드 작성" \
+  --body "## 목표
+AI Agent가 자동으로 PR을 생성하고 관리하는 방법을 문서화합니다.
+
+## 작업 내용
+- [ ] AI Agent PR 생성 워크플로우 문서화
+- [ ] GitHub CLI 사용법 가이드
+- [ ] 자동 커밋 메시지 컨벤션 정의
+- [ ] PR 템플릿 최적화 (AI 친화적)
+- [ ] 자동 리뷰 및 머지 가이드라인
+
+## 포함할 내용
+1. Claude Code를 사용한 PR 생성
+2. gh CLI를 사용한 자동화 스크립트
+3. GitHub Actions를 통한 AI 트리거 워크플로우
+4. 베스트 프랙티스 및 주의사항
+
+## 참고 자료
+- GitHub CLI documentation
+- Claude Code best practices
+- Conventional commits specification" \
+  --label "documentation,automation" \
+  --format json)
+
+ISSUE_6_NUMBER=$(echo "$ISSUE_6" | jq -r '.number')
+ISSUE_6_ID=$(echo "$ISSUE_6" | jq -r '.id')
+echo "  ✓ Issue #$ISSUE_6_NUMBER created"
+echo ""
+
+# Step 3: Add issues to project board
+echo "[3/3] Adding issues to project board..."
+echo ""
+
+# Get project ID and field IDs
+PROJECT_ID=$(gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json | jq -r '.id')
+echo "Project ID: $PROJECT_ID"
+
+# Add each issue to the project
+echo "Adding issue #$ISSUE_1_NUMBER to project..."
+gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "https://github.com/$OWNER/$REPO/issues/$ISSUE_1_NUMBER"
+
+echo "Adding issue #$ISSUE_2_NUMBER to project..."
+gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "https://github.com/$OWNER/$REPO/issues/$ISSUE_2_NUMBER"
+
+echo "Adding issue #$ISSUE_3_NUMBER to project..."
+gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "https://github.com/$OWNER/$REPO/issues/$ISSUE_3_NUMBER"
+
+echo "Adding issue #$ISSUE_4_NUMBER to project..."
+gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "https://github.com/$OWNER/$REPO/issues/$ISSUE_4_NUMBER"
+
+echo "Adding issue #$ISSUE_5_NUMBER to project..."
+gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "https://github.com/$OWNER/$REPO/issues/$ISSUE_5_NUMBER"
+
+echo "Adding issue #$ISSUE_6_NUMBER to project..."
+gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "https://github.com/$OWNER/$REPO/issues/$ISSUE_6_NUMBER"
+
+echo ""
+echo "=================================================="
+echo "Setup Complete!"
+echo "=================================================="
+echo ""
+echo "Project URL: $PROJECT_URL"
+echo ""
+echo "Created Issues:"
+echo "  #$ISSUE_1_NUMBER - NPM 퍼블리시 설정 및 테스트"
+echo "  #$ISSUE_2_NUMBER - CI/CD 워크플로우 테스트"
+echo "  #$ISSUE_3_NUMBER - 패키지 버전 관리 자동화"
+echo "  #$ISSUE_4_NUMBER - 예제 프로젝트 추가"
+echo "  #$ISSUE_5_NUMBER - 단위 테스트 추가"
+echo "  #$ISSUE_6_NUMBER - AI Agent PR 자동화 가이드 작성"
+echo ""
+echo "All issues have been added to the 'Todo' status on the project board."
+echo "Visit $PROJECT_URL to view your kanban board!"
+echo ""

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { hello } from '../index';
+
+describe('hello', () => {
+  it('should return "Hello, World!" when called without arguments', () => {
+    const result = hello();
+    expect(result).toBe('Hello, World!');
+  });
+
+  it('should return personalized greeting when name is provided', () => {
+    const result = hello('Alice');
+    expect(result).toBe('Hello, Alice!');
+  });
+
+  it('should handle empty string', () => {
+    const result = hello('');
+    expect(result).toBe('Hello, World!');
+  });
+
+  it('should handle special characters in name', () => {
+    const result = hello('世界');
+    expect(result).toBe('Hello, 世界!');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.config.ts',
+        '**/*.d.ts',
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

This PR adds comprehensive testing infrastructure and dual publishing setup for the NPM package boilerplate.

### Changes

#### Testing Infrastructure
- ✅ Add Vitest for unit testing with TypeScript support
- ✅ Create `vitest.config.ts` with coverage configuration
- ✅ Add sample unit tests for `hello()` function in `src/__tests__/index.test.ts`
- ✅ Update `package.json` with test scripts: `test`, `test:ui`, `test:run`, `test:coverage`
- ✅ Update `tsconfig.json` to exclude test files from build
- ✅ Add `coverage/` to `.gitignore`

#### Dual Publishing Setup
- ✅ Configure GitHub Packages publishing (always enabled)
- ✅ Configure NPM public registry publishing (optional, requires `NPM_TOKEN`)
- ✅ Add NPM_TOKEN detection with graceful skip and clear logging
- ✅ Update `package.json` with repository info and publishConfig
- ✅ Add comprehensive setup documentation in `docs/NPM-PUBLISH-SETUP.md`

#### CI/CD Improvements
- ✅ Update CI workflow to run tests before build
- ✅ Update publish workflow to run tests before publishing
- ✅ Add conditional NPM publishing based on `NPM_TOKEN` availability

### Publishing Behavior

**With NPM_TOKEN configured:**
- ✅ Publishes to NPM Public Registry
- ✅ Publishes to GitHub Packages

**Without NPM_TOKEN:**
- ⚠️ Skips NPM publish with clear warning message
- ✅ Still publishes to GitHub Packages

### Test Plan

- [x] Unit tests pass locally (`npm run test:run`)
- [x] Build succeeds (`npm run build`)
- [x] Type check passes (`npm run typecheck`)
- [ ] CI workflow runs successfully on this PR
- [ ] All checks pass

### Documentation

Added `docs/NPM-PUBLISH-SETUP.md` with:
- Step-by-step NPM token generation guide
- GitHub Secrets configuration instructions
- Publishing workflow explanation
- Troubleshooting section

🤖 Generated with [Claude Code](https://claude.com/claude-code)